### PR TITLE
Allow user defined theme repo

### DIFF
--- a/blueacornui/commands/install.js
+++ b/blueacornui/commands/install.js
@@ -3,7 +3,7 @@ import glob from 'glob';
 import isInstalled, { isComposerPackageInstalled } from '../helpers/is-installed';
 import { createBaseTheme, installComposerPackage } from '../helpers/install-theme';
 import inquirer from 'inquirer';
-import { success, info } from '../helpers/reporter';
+import {success, info, error} from '../helpers/reporter';
 
 const settingsLookup = (theme) => {
     const files = [];
@@ -69,28 +69,28 @@ const collectThemes = async () => {
 
 export default async (program) => {
     const installed = await isInstalled();
-    if (!installed) {
-        program
-            .command('install')
-            .description('installs green-pistachio build tools')
-            .action(async () => {
+
+    program
+        .command('install')
+        .description('installs green-pistachio build tools')
+        .action(async () => {
+            if (installed) {
+                error('Green Pistachio Build Tools have already been installed. To rerun the installer, delete your project\'s gulp-config.js file.');
+            } else {
                 info('collecting installed themes');
                 let themes = await collectThemes();
 
-                if (!themes.find((theme) => theme.name === 'site' && theme.vendor === 'BlueAcorn')) {
-                    const { should_install_base } = await inquirer
-                        .prompt([{
-                            type: 'confirm',
-                            name: 'should_install_base',
-                            message: 'Do you wish to install the blueacorn site base theme now?'
-                        }]);
+                const { should_install_base } = await inquirer
+                    .prompt([{
+                        type: 'confirm',
+                        name: 'should_install_base',
+                        message: 'Do you wish to install a base theme now?'
+                    }]);
 
-                    if (should_install_base) {
-                        info('installing blueacorn site base theme');
-                        await createBaseTheme();
-                        themes = await collectThemes();
-                        success('blueacorn site base theme successfully installed');
-                    }
+                if (should_install_base) {
+                    await createBaseTheme();
+                    themes = await collectThemes();
+                    success('Base theme successfully installed.');
                 }
 
                 const cacheCleanInstalled = await isComposerPackageInstalled('mage2tv/magento-cache-clean');
@@ -112,8 +112,9 @@ export default async (program) => {
                     selected_themes.map(selected_theme => themes.find(theme => theme.fullName === selected_theme))
                 );
                 success('created config file');
-            })
-    }
+            }
+        })
+
 
     return program;
 };

--- a/blueacornui/commands/install.js
+++ b/blueacornui/commands/install.js
@@ -3,7 +3,7 @@ import glob from 'glob';
 import isInstalled, { isComposerPackageInstalled } from '../helpers/is-installed';
 import { createBaseTheme, installComposerPackage } from '../helpers/install-theme';
 import inquirer from 'inquirer';
-import {success, info, error} from '../helpers/reporter';
+import { success, info, error } from '../helpers/reporter';
 
 const settingsLookup = (theme) => {
     const files = [];

--- a/blueacornui/helpers/install-theme.js
+++ b/blueacornui/helpers/install-theme.js
@@ -4,13 +4,14 @@ import mkdirp from 'mkdirp';
 import { userInfo } from 'os';
 import path from 'path';
 import exec from '../helpers/exec';
-import { error } from './reporter';
+import {error, info} from './reporter';
+import inquirer from 'inquirer';
 
 export const getHomeDir = () => path.resolve(userInfo().homedir, '.green-pistachio');
 
 export const getHomeThemeDir = () => path.resolve(getHomeDir(), 'theme');
 
-export const getAppThemeDir = () => path.resolve(process.cwd(), 'app', 'design', 'frontend', 'BlueAcorn', 'site');
+export const getAppThemeDir = () => path.resolve(process.cwd(), 'app', 'design');
 
 export const rimrafP = async (dir) => new Promise(resolve => rimraf(dir, resolve));
 
@@ -27,8 +28,16 @@ export const copyP = async (source, destination) => new Promise((resolve, reject
 
 export const cloneRepo = async (dir) => {
     try {
+        const { theme_repo } = await inquirer
+            .prompt([{
+                type: 'input',
+                name: 'theme_repo',
+                message: 'Where should the base theme be cloned from?',
+                default: 'git@github.com:BlueAcornInc/ba-green-pistachio-theme-m2.git'
+            }]);
+
         await exec(
-            `git clone git@github.com:BlueAcornInc/ba-green-pistachio-theme-m2.git .`,
+            `git clone ${theme_repo} .`,
             { cwd: dir }
         )
     } catch (err) {
@@ -43,10 +52,11 @@ export const createBaseTheme = async () => {
     await mkdirp(homeThemeDir);
 
     try {
+        info('installing base theme');
         await cloneRepo(homeThemeDir);
-        await mkdirp(path.join(process.cwd(), 'app', 'design', 'frontend', 'BlueAcorn'));
+        await mkdirp(path.join(process.cwd(), 'app', 'design'));
         await copyP(
-            path.resolve(homeThemeDir, 'app', 'design', 'frontend', 'BlueAcorn', 'site'),
+            path.resolve(homeThemeDir, 'app', 'design'),
             appThemeDir
         );
     } catch (err) {

--- a/blueacornui/helpers/install-theme.js
+++ b/blueacornui/helpers/install-theme.js
@@ -4,7 +4,7 @@ import mkdirp from 'mkdirp';
 import { userInfo } from 'os';
 import path from 'path';
 import exec from '../helpers/exec';
-import {error, info} from './reporter';
+import { error, info } from './reporter';
 import inquirer from 'inquirer';
 
 export const getHomeDir = () => path.resolve(userInfo().homedir, '.green-pistachio');


### PR DESCRIPTION
This modifies the installation process to let the user specify a remote repo from which the theme should be installed, rather than forcing the installation to use the Github repo (https://github.com/BlueAcornInc/ba-green-pistachio-theme-m2), which is out of date compared to the actively maintained one on Bitbucket (https://bitbucket.org/blueacorn/theme-frontend-green-pistachio/src/master/). The Github repo still acts as the default, in the interest of keeping this tooling relevant for the open-source community.

Changes:
- User is prompted whether to install a 'base theme' rather than specifically asking if they want to install the 'blue acorn site base theme', since this change should allow for any theme to be installed.
- Removed the check for whether a `BlueAcorn/site` directory already exists in `app/design/frontend` before asking the above prompt. In theory, we should be able to install multiple themes on a project using this tooling, of different vendor/theme names.
- Altered the logic in the `install` command so that a valid command is always found and initiated; previously, if a `gulp-config.js` file was already present in the project root, the installer would error with the following:
```
error: unknown command 'install'. See 'gpc --help'.
error Command failed with exit code 1.
```
Now, the installer will provide a more helpful error message.
- Removed the area name, vendor name, and theme name from the hardcoded path structures in `install-themes.js`. This would allow us to use this tooling to install adminhtml themes, or themes of differing vendors/names.

Fixes: https://github.com/BlueAcornInc/green-pistachio/issues/3