### PR TITLE
Fixing an issue where the public path is set wrong

### DIFF
--- a/src/Webpack/ConfigFactory.ts
+++ b/src/Webpack/ConfigFactory.ts
@@ -152,8 +152,8 @@ export default class WebpackConfigFactory {
             context: project.getRootDirectory(),
             output: {
                 path: project.getRootDirectory(),
-                publicPath: '',
-                filename: '[name].js',
+                publicPath: project.getRootDirectory(),
+                filename: '[name].js'
             },
             module: {
                 rules: [


### PR DESCRIPTION
When publicPath isn't set correctly to match the same as Path it causes issues with loading content in webpack-dev-server when loading via script tag.